### PR TITLE
Rename simplejson to json for recent python versions

### DIFF
--- a/getConfig.py
+++ b/getConfig.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import simplejson as json
+import json
 
 ERR_PRINT = 5;
 def get_conf(conffile):

--- a/py_requirements
+++ b/py_requirements
@@ -1,2 +1,2 @@
 pathlib
-simplejson
+json


### PR DESCRIPTION
For any python version since 2.6, [Simplejson is included in the distribution](https://bugs.python.org/issue2750) and renamed to just `json`. This patch adjusts the import and requirements accordingly so it doesn't break on newer systems (like mine did).