### PR TITLE
Fix orientation script for external monitors

### DIFF
--- a/utilities/orientation
+++ b/utilities/orientation
@@ -1,6 +1,6 @@
 #!/bin/bash
 # return orientation of screen, code written to avoid issues with the screen not being primary
-device=" -w -m 1 connected"
+device=" -w -m 1 primary"
 status="$(xrandr -q|grep ${device}|awk '{print $3}')"
 # if [ $status == 'primary' ]; then
 #    state="$(xrandr -q|grep ${device}|awk '{print $5}')"


### PR DESCRIPTION
If the monitor is connected before the system boot, then after boot you need to reconnect the monitor, otherwise gestures don't work.
To fix this problem and don't reconnect the monitor on every boot I found that all I had to do was change "connected" to "primary".